### PR TITLE
Q42021 SourceCred Distribution Schedule

### DIFF
--- a/config/grain.json
+++ b/config/grain.json
@@ -1,7 +1,7 @@
 {
-  "immediatePerWeek": 500,
+  "immediatePerWeek": 1000,
   "balancedPerWeek": 0,
-  "recentPerWeek": 500,
+  "recentPerWeek": 1000,
   "recentWeeklyDecayRate": 0.25,
   "maxSimultaneousDistributions": 1
 }


### PR DESCRIPTION
Increase the weekly Cred allocation to 2000 per week from 1000 while maintaining the current allocation structure.