### PR TITLE
Dec 2021 Grain Schedule

### DIFF
--- a/config/grain.json
+++ b/config/grain.json
@@ -1,7 +1,7 @@
 {
-  "immediatePerWeek": 1000,
+  "immediatePerWeek": 2000,
   "balancedPerWeek": 0,
-  "recentPerWeek": 1000,
+  "recentPerWeek": 2000,
   "recentWeeklyDecayRate": 0.25,
   "maxSimultaneousDistributions": 1
 }


### PR DESCRIPTION
Increase the budget to 4k per week for December 2021 distributions.