### PR TITLE
Increase grain to 1.5k/week

### DIFF
--- a/config/grain.json
+++ b/config/grain.json
@@ -1,7 +1,7 @@
 {
-  "immediatePerWeek": 500,
+  "immediatePerWeek": 750,
   "balancedPerWeek": 0,
-  "recentPerWeek": 500,
+  "recentPerWeek": 750,
   "recentWeeklyDecayRate": 0.25,
   "maxSimultaneousDistributions": 1
 }


### PR DESCRIPTION
Increasing grain distribution back to 1.5k per week based on arrival of Gitcoin GR12 matching funds.